### PR TITLE
jicofo: configure trusted-domains if recording is enabled

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,8 +209,8 @@ services:
             - JICOFO_CONF_SINGLE_PARTICIPANT_TIMEOUT
             - JICOFO_ENABLE_HEALTH_CHECKS
             - JICOFO_SHORT_ID
-            - JICOFO_RESERVATION_ENABLED 
-            - JICOFO_RESERVATION_REST_BASE_URL 
+            - JICOFO_RESERVATION_ENABLED
+            - JICOFO_RESERVATION_REST_BASE_URL
             - JIBRI_BREWERY_MUC
             - JIBRI_REQUEST_RETRIES
             - JIBRI_PENDING_TIMEOUT
@@ -224,6 +224,7 @@ services:
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_MUC_DOMAIN
+            - XMPP_RECORDER_DOMAIN
             - XMPP_SERVER
         depends_on:
             - prosody

--- a/examples/traefik-v2/docker-compose.yml
+++ b/examples/traefik-v2/docker-compose.yml
@@ -96,7 +96,7 @@ services:
             - XMPP_RECORDER_DOMAIN
             - TOKEN_AUTH_URL
         networks:
-            # traefik: change the following line to your external docker network 
+            # traefik: change the following line to your external docker network
             web:
             meet.jitsi:
                 aliases:
@@ -221,6 +221,7 @@ services:
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_MUC_DOMAIN
+            - XMPP_RECORDER_DOMAIN
             - XMPP_SERVER
         depends_on:
             - prosody
@@ -265,6 +266,6 @@ services:
 # Custom network so all services can communicate using a FQDN
 networks:
     meet.jitsi:
-    # traefik: change the following line to your external docker network 
+    # traefik: change the following line to your external docker network
     web:
         external: true

--- a/examples/traefik/docker-compose.yml
+++ b/examples/traefik/docker-compose.yml
@@ -37,7 +37,7 @@ services:
             - JIBRI_RECORDER_PASSWORD
             - ENABLE_RECORDING
         networks:
-            # traefik: change the following line to your external docker network 
+            # traefik: change the following line to your external docker network
             web:
             meet.jitsi:
                 aliases:
@@ -47,7 +47,7 @@ services:
             - "traefik.docker.network=web"
             - "traefik.enable=true"
             - "traefik.backend=jc_backend"
-            # traefik: change that to your actual fqdn 
+            # traefik: change that to your actual fqdn
             - "traefik.basic.frontend.rule=Host:your.host.name"
             - "traefik.basic.port=80"
 
@@ -128,6 +128,7 @@ services:
             - XMPP_DOMAIN
             - XMPP_AUTH_DOMAIN
             - XMPP_INTERNAL_MUC_DOMAIN
+            - XMPP_RECORDER_DOMAIN
             - XMPP_SERVER
             - JICOFO_COMPONENT_SECRET
             - JICOFO_AUTH_USER
@@ -175,6 +176,6 @@ services:
 # Custom network so all services can communicate using a FQDN
 networks:
     meet.jitsi:
-    # traefik: change the following line to your external docker network 
+    # traefik: change the following line to your external docker network
     web:
         external: true

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -120,7 +120,7 @@ jicofo {
       // two MUST be in sync (otherwise bridges will crash because they won't know how to
       // deal with octo channels).
       enabled = {{ $ENABLE_OCTO }}
-      
+
       id = "{{ .Env.JICOFO_SHORT_ID | default "1" }}"
     }
 
@@ -134,11 +134,14 @@ jicofo {
         hostname = "{{ .Env.XMPP_SERVER }}"
         domain = "{{ .Env.XMPP_AUTH_DOMAIN }}"
         username = "{{ .Env.JICOFO_AUTH_USER }}"
-        password = "{{ .Env.JICOFO_AUTH_PASSWORD }}"  
+        password = "{{ .Env.JICOFO_AUTH_PASSWORD }}"
         conference-muc-jid = "{{ .Env.XMPP_MUC_DOMAIN }}"
         client-proxy = "focus.{{ .Env.XMPP_DOMAIN }}"
         disable-certificate-verification = true
       }
+      {{ if $ENABLE_RECORDING }}
+      trusted-domains = [ "{{ .Env.XMPP_RECORDER_DOMAIN }}" ]
+      {{ end }}
     }
 
     {{ if .Env.JICOFO_RESERVATION_ENABLED | default "false" | toBool }}


### PR DESCRIPTION
Configures https://github.com/jitsi/jicofo/blob/master/src/main/resources/reference.conf#L330 using the same env name as used for prosody & web