### PR TITLE
jibri: include python3 in the image for our ffmpeg wrapper

### DIFF
--- a/jibri/Dockerfile
+++ b/jibri/Dockerfile
@@ -42,10 +42,9 @@ RUN \
 
 RUN \
         apt-dpkg-wrap apt-get update \
-        && apt-dpkg-wrap apt-get install -y jitsi-upload-integrations jq \
+        && apt-dpkg-wrap apt-get install -y jitsi-upload-integrations jq python3 \
         && apt-cleanup
 
 COPY rootfs/ /
 
 VOLUME /config
-


### PR DESCRIPTION
Another one that probably isn't for upstream. We want python3 for our ffmpeg wrapper script