### PR TITLE
Jibri: ensure Chrome has been started at least once before Jibri starts

### DIFF
--- a/jibri/rootfs/etc/services.d/40-jibri/run
+++ b/jibri/rootfs/etc/services.d/40-jibri/run
@@ -4,5 +4,4 @@
 HOME=/home/jibri
 
 DAEMON=/opt/jitsi/jibri/launch.sh
-exec s6-setuidgid jibri /bin/bash -c "exec $DAEMON"
-
+exec s6-setuidgid jibri /bin/bash -c "/usr/bin/first-start-chrome.sh && exec $DAEMON"

--- a/jibri/rootfs/usr/bin/first-start-chrome.sh
+++ b/jibri/rootfs/usr/bin/first-start-chrome.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o pipefail -xeu
+
+google-chrome "${PUBLIC_URL:-https://google.com}" &
+PID=$!
+sleep 10
+kill $PID


### PR DESCRIPTION
Chrome can take a long time on first boot and this can cause issues timing out recordings.
* https://community.jitsi.org/t/jibri-failed-to-send-start-jibri-iq-org-jitsi-jicofo-recording-jibri-jibrisession-startexception-unexpected-response/89800/48
* https://community.jitsi.org/t/error-to-start-recording-but-jibri-goes-busy-and-does-record-the-room-happens-only-on-first-record-attempt/74906/6

This PR solves the problem slightly differently from the links as rather than using `/home/jibri/.icewm/startup` it places it in the Jibri startup sequence. This is ensure there are no races between Jibri and Chome and that Chrome has been started up and killed before Jibri is ever attempted to be started.