### PR TITLE
Jicofo: make the XMPP reply-timeout configurable, keeping the default at 15 seconds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -278,6 +278,7 @@ services:
             - XMPP_INTERNAL_MUC_DOMAIN
             - XMPP_MUC_DOMAIN
             - XMPP_RECORDER_DOMAIN
+            - XMPP_REPLY_TIMEOUT
             - XMPP_SERVER
             - XMPP_PORT
         depends_on:

--- a/jicofo/rootfs/defaults/jicofo.conf
+++ b/jicofo/rootfs/defaults/jicofo.conf
@@ -14,6 +14,7 @@
 {{ $XMPP_INTERNAL_MUC_DOMAIN := .Env.XMPP_INTERNAL_MUC_DOMAIN | default "internal-muc.meet.jitsi" -}}
 {{ $XMPP_DOMAIN := .Env.XMPP_DOMAIN | default "meet.jitsi" -}}
 {{ $XMPP_RECORDER_DOMAIN := .Env.XMPP_RECORDER_DOMAIN | default "recorder.meet.jitsi" -}}
+{{ $XMPP_REPLY_TIMEOUT := .Env.XMPP_REPLY_TIMEOUT | default "15 seconds" -}}
 {{ $XMPP_PORT := .Env.XMPP_PORT | default "5222" -}}
 {{ $XMPP_SERVER := .Env.XMPP_SERVER | default "xmpp.meet.jitsi" -}}
 
@@ -148,6 +149,7 @@ jicofo {
         domain = "{{ $XMPP_AUTH_DOMAIN }}"
         username = "{{ $JICOFO_AUTH_USER }}"
         password = "{{ .Env.JICOFO_AUTH_PASSWORD }}"
+        reply-timeout = "{{ $XMPP_REPLY_TIMEOUT }}"
         conference-muc-jid = "{{ $XMPP_MUC_DOMAIN }}"
         client-proxy = "focus.{{ $XMPP_DOMAIN }}"
         disable-certificate-verification = true


### PR DESCRIPTION
Belt and braces solving of slow Jibri startup along with #18 

Allow configuration of `jicofo.xmpp.client.reply-timeout` so that it can be raised if required. Default is kept at `15 seconds` as per https://github.com/jitsi/jicofo/blob/master/jicofo-selector/src/main/resources/reference.conf#L334