### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/docker-publish-individual.yml
+++ b/.github/workflows/docker-publish-individual.yml
@@ -1,0 +1,65 @@
+name: Docker Publish Jitsi Component
+
+on:
+  workflow_call:
+    inputs:
+      folder:
+        required: true
+        type: string
+    secrets:
+      github-token:
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_BASE_PATH: ghcr.io/${{ github.repository }}
+  BASE_TAG: ${{ github.ref_name }}
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.github-token }}
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ env.REGISTRY_BASE_PATH }}/${{ inputs.folder }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: "${{ inputs.folder }}"
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          "BASE_TAG=${{ env.BASE_TAG }}"
+          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
+      if: contains(github.ref_name, '/merge') == false
+
+    - name: Build and push Docker image for PR
+      uses: docker/build-push-action@v2
+      with:
+        context: "${{ inputs.folder }}"
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          "BASE_TAG=${{ github.base_ref }}"
+          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
+      if: contains(github.ref_name, '/merge')

--- a/.github/workflows/docker-publish-individual.yml
+++ b/.github/workflows/docker-publish-individual.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -36,12 +36,12 @@ jobs:
 
     - name: Extract Docker metadata
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: ${{ env.REGISTRY_BASE_PATH }}/${{ inputs.folder }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         context: "${{ inputs.folder }}"
         push: ${{ github.event_name != 'pull_request' }}
@@ -53,7 +53,7 @@ jobs:
       if: contains(github.ref_name, '/merge') == false
 
     - name: Build and push Docker image for PR
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         context: "${{ inputs.folder }}"
         push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker-publish-individual.yml
+++ b/.github/workflows/docker-publish-individual.yml
@@ -39,6 +39,16 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         images: ${{ env.REGISTRY_BASE_PATH }}/${{ inputs.folder }}
+        # Turn off auto-latest, as we want to exclude openshift tags from that
+        flavor: |
+          latest=false
+        # 1-3. Generate the default docker tags, 4. generate latest if git tag is on the default branch, 5. generate openshift-latest if git tag is on the openshift branch
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+          type=ref,event=tag,value=latest,enable={{is_default_branch}}
+          type=ref,event=tag,value=openshift-latest,enable=${{ github.ref == 'refs/heads/openshift' }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,436 +7,80 @@ on:
   pull_request:
     branches: [ main, master, testing, openshift ]
 
-env:
-  REGISTRY: ghcr.io
-  REGISTRY_BASE_PATH: ghcr.io/${{ github.repository }}
-  BASE_TAG: ${{ github.ref_name }}
-
 jobs:
   build-push-base:
-    env:
-      IMAGE_NAME: base
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.REGISTRY_BASE_PATH }}/${{ env.IMAGE_NAME }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "base"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ env.BASE_TAG }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge') == false
-
-    - name: Build and push Docker image for PR
-      uses: docker/build-push-action@v2
-      with:
-        context: "base"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ github.base_ref }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge')
+    uses: ./.github/workflows/docker-publish-individual.yml
+    with:
+      folder: base
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-push-base-java:
-    env:
-      IMAGE_NAME: base-java
-
-    runs-on: ubuntu-latest
-
     needs:
     - build-push-base
 
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.REGISTRY_BASE_PATH }}/${{ env.IMAGE_NAME }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "base-java"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ env.BASE_TAG }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge') == false
-
-    - name: Build and push Docker image for PR
-      uses: docker/build-push-action@v2
-      with:
-        context: "base-java"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ github.base_ref }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge')
+    uses: ./.github/workflows/docker-publish-individual.yml
+    with:
+      folder: base-java
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-push-jibri:
-    env:
-      IMAGE_NAME: jibri
-
-    runs-on: ubuntu-latest
-
     needs:
     - build-push-base-java
 
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.REGISTRY_BASE_PATH }}/${{ env.IMAGE_NAME }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "jibri"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ env.BASE_TAG }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge') == false
-
-    - name: Build and push Docker image for PR
-      uses: docker/build-push-action@v2
-      with:
-        context: "jibri"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ github.base_ref }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge')
+    uses: ./.github/workflows/docker-publish-individual.yml
+    with:
+      folder: jibri
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
   
   build-push-jicofo:
-    env:
-      IMAGE_NAME: jicofo
-
-    runs-on: ubuntu-latest
-
     needs:
     - build-push-base-java
 
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.REGISTRY_BASE_PATH }}/${{ env.IMAGE_NAME }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "jicofo"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ env.BASE_TAG }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge') == false
-
-    - name: Build and push Docker image for PR
-      uses: docker/build-push-action@v2
-      with:
-        context: "jicofo"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ github.base_ref }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge')
+    uses: ./.github/workflows/docker-publish-individual.yml
+    with:
+      folder: jicofo
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-push-jigasi:
-    env:
-      IMAGE_NAME: jigasi
-
-    runs-on: ubuntu-latest
-
     needs:
     - build-push-base-java
 
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.REGISTRY_BASE_PATH }}/${{ env.IMAGE_NAME }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "jigasi"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ env.BASE_TAG }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge') == false
-          
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "jigasi"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ github.base_ref }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge')
+    uses: ./.github/workflows/docker-publish-individual.yml
+    with:
+      folder: jigasi
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-push-jvb:
-    env:
-      IMAGE_NAME: jvb
-    
-    runs-on: ubuntu-latest
-
     needs:
     - build-push-base-java
 
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.REGISTRY_BASE_PATH }}/${{ env.IMAGE_NAME }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "jvb"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ env.BASE_TAG }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge') == false
-          
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "jvb"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ github.base_ref }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge')
+    uses: ./.github/workflows/docker-publish-individual.yml
+    with:
+      folder: jvb
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-push-prosody:
-    env:
-      IMAGE_NAME: prosody
-
-    runs-on: ubuntu-latest
-
     needs:
     - build-push-base
 
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.REGISTRY_BASE_PATH }}/${{ env.IMAGE_NAME }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "prosody"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ env.BASE_TAG }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge') == false
-          
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "prosody"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ github.base_ref }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge')
+    uses: ./.github/workflows/docker-publish-individual.yml
+    with:
+      folder: prosody
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-push-web:
-    env:
-      IMAGE_NAME: web
-
-    runs-on: ubuntu-latest
-
     needs:
     - build-push-base
-    
-    permissions:
-      contents: read
-      packages: write
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.REGISTRY_BASE_PATH }}/${{ env.IMAGE_NAME }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "web"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ env.BASE_TAG }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge') == false
-          
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: "web"
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          "BASE_TAG=${{ github.base_ref }}"
-          "JITSI_REPO=${{ env.REGISTRY_BASE_PATH }}"
-      if: contains(github.ref_name, '/merge')
+    uses: ./.github/workflows/docker-publish-individual.yml
+    with:
+      folder: web
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Use a reusable workflow rather than c/p'ing for each component
* Upgrade action versions to remove Node 12 deprecation warnings
* Stop generating `latest` Docker tag on the `openshift` branch and on non-tags